### PR TITLE
Use different precontent block for list pages #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,32 @@ The app comes with a SiteVar model for storing site-specific variables or chunks
 content. You can store any variable for use with your own templates. Variables used by
 the default templates/models include:
 
+- `base_template` - The base template to use for generic pages. Defaults to
+  `genericsite/base.html`.
 - `copyright_holder` - Custom name for the copyright holder if using the default
   copyright notice. Falls back to `site.name` if not provided.
 - `copyright_notice` - HTML to include in the copyright notice section of the footer
   (replaces the default copyright notice).
-- `default_detail_content_template` - Default template to use for the `content` block
+- `detail_precontent_template` - Default template to use for the `precontent` block for
+  detail pages.
+- `detail_content_template` - Default template to use for the `content` block for detail
+  pages.
+- `detail_postcontent_template` - Default template to use for the `postcontent` block
   for detail pages.
-- `default_list_content_template` - Default template to use for the `content` block for
+- `list_postcontent_template` - Default template to use for the `postcontent` block for
   list pages.
-- `default_footer_template` - Default template to use for the `footer` block.
-- `default_header_template` - Default template to use for the `header` block.
+- `list_precontent_template` - Default template to use for the `precontent` block for
+  list pages.
+- `list_content_template` - Default template to use for the `content` block for list
+  pages.
+- `footer_template` - Default template to use for the `footer` block.
+- `header_template` - Default template to use for the `header` block.
 - `default_icon` - Name of a Bootstrap icon to use by default if the object provides
   none.
-- `default_postcontent_template` - Default template to use for the `postcontent` block.
-- `default_precontent_template` - Default template to use for the `precontent` block.
+- `paginate_by` - Items per page on list pages, same as Django's ListView, see
+  [pagination](https://docs.djangoproject.com/en/dev/ref/paginator/) in the Django docs.
+- `paginate_orphans` - Same as Django's ListView, see
+  [pagination](https://docs.djangoproject.com/en/dev/ref/paginator/) in the Django docs.
 
 ## Images and Media
 

--- a/src/genericsite/apps.py
+++ b/src/genericsite/apps.py
@@ -17,21 +17,24 @@ class GenericsiteConfig(AppConfig):
     # ========================================================================
     # Our configs
     # ========================================================================
+    base_template = "genericsite/base.html"
+    bootstrap_container_class = "container"
     paginate_by = 15
     paginate_orphans = 2
 
     # Default block templates are injected to the template context by our context
     # processor, so they're accessible even to 3rd party views.
-    default_header_template = "genericsite/blocks/header_simple.html"
-    default_footer_template = "genericsite/blocks/footer_simple.html"
-    default_precontent_template = "genericsite/blocks/empty.html"
-    default_postcontent_template = "genericsite/blocks/empty.html"
-    default_content_template = "genericsite/blocks/article_text.html"
-    default_list_content_template = "genericsite/blocks/article_list_blog.html"
+    header_template = "genericsite/blocks/header_simple.html"
+    footer_template = "genericsite/blocks/footer_simple.html"
+
+    detail_precontent_template = "genericsite/blocks/empty.html"
+    detail_content_template = "genericsite/blocks/article_text.html"
+    detail_postcontent_template = "genericsite/blocks/empty.html"
+
     # TODO list_precontent_template should probably be a custom block, not article_text
-    default_list_precontent_template = "genericsite/blocks/article_text.html"
-    default_list_postcontent_template = "genericsite/blocks/empty.html"
-    bootstrap_container_class = "container"
+    list_precontent_template = "genericsite/blocks/article_text.html"
+    list_content_template = "genericsite/blocks/article_list_blog.html"
+    list_postcontent_template = "genericsite/blocks/empty.html"
 
     default_icon = "file-text"
     fallback_copyright = _("© Copyright {} {}. All rights reserved.")
@@ -87,27 +90,12 @@ class GenericsiteConfig(AppConfig):
 # A context processor to add our vars to template contexts:
 def context_defaults(request):
     """Supply default context variables for GenericSite templates"""
-    # We don't access the class above directly, because the end user can make thier own
-    # subclass to customize the defaults. Use the configured class according to Django.
-    conf = apps.get_app_config("genericsite")
     var = request.site.vars
     return {
-        "header_template": var.get_value(
-            "default_header_template", conf.default_header_template
-        ),
-        "footer_template": var.get_value(
-            "default_footer_template", conf.default_footer_template
-        ),
-        "precontent_template": var.get_value(
-            "default_precontent_template", conf.default_precontent_template
-        ),
-        "postcontent_template": var.get_value(
-            "default_postcontent_template", conf.default_postcontent_template
-        ),
-        "content_template": var.get_value(
-            "default_content_template", conf.default_content_template
-        ),
-        "bootstrap_container_class": var.get_value(
-            "bootstrap_container_class", conf.bootstrap_container_class
-        ),
+        "header_template": var.get_value("header_template"),
+        "footer_template": var.get_value("footer_template"),
+        "precontent_template": var.get_value("detail_precontent_template"),
+        "postcontent_template": var.get_value("detail_postcontent_template"),
+        "content_template": var.get_value("detail_content_template"),
+        "bootstrap_container_class": var.get_value("bootstrap_container_class"),
     }

--- a/src/genericsite/apps.py
+++ b/src/genericsite/apps.py
@@ -18,6 +18,15 @@ class GenericsiteConfig(AppConfig):
     # Our configs
     # ========================================================================
     base_template = "genericsite/base.html"
+    # List of blocks in the base template that include other templates, and can
+    # be overridden on a per-view basis or with SiteVars.
+    base_blocks = (
+        "header_template",
+        "precontent_template",
+        "content_template",
+        "postcontent_template",
+        "footer_template",
+    )
     bootstrap_container_class = "container"
     paginate_by = 15
     paginate_orphans = 2

--- a/src/genericsite/models.py
+++ b/src/genericsite/models.py
@@ -41,7 +41,7 @@ class SiteVarQueryset(models.QuerySet):
         # Returns the string if set, or "Ignore" if not set
         x = site.vars.get_value("abort_retry_ignore", "Ignore")
         # Returns the number of pages as an integer. Note the default should be a str.
-        num_items = site.vars.get_value("items_per_page", default="10", asa=int)
+        num_items = site.vars.get_value("paginate_by", default="10", asa=int)
         # Parses the value as JSON and returns the result
         data = site.vars.get_value("json_data", "{}", json.loads)
         """
@@ -52,7 +52,8 @@ class SiteVarQueryset(models.QuerySet):
             conf = apps.get_app_config("genericsite")
             if hasattr(conf, name):
                 return asa(getattr(conf, name))
-            return asa(default)
+            # This allows None as a default, without crashing on e.g. `int(None)`
+            return asa(default) if default is not None else default
         # Note explicitly NOT catching MultipleObjectsReturned, that's still an error
 
 

--- a/src/genericsite/templates/genericsite/base.html
+++ b/src/genericsite/templates/genericsite/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>{% load i18n static %}
+<!DOCTYPE html>{% load i18n static genericsite %}
 <html prefix="og: https://ogp.me/ns#
 article: https://ogp.me/ns/article#
 book: https://ogp.me/ns/book#
@@ -20,6 +20,7 @@ video: https://ogp.me/ns/video#
   {% block extra_head %}
   <link rel="stylesheet" href="{% static 'generic.css' %}">
   {% endblock %}
+  {% sitevar "bootstrap_container_class" as bootstrap_container_class %}
 </head>
 <body class="{% block body_class %}{% endblock body_class %}">
   {% block header %}

--- a/src/genericsite/templates/genericsite/base.html
+++ b/src/genericsite/templates/genericsite/base.html
@@ -23,7 +23,7 @@ video: https://ogp.me/ns/video#
 </head>
 <body class="{% block body_class %}{% endblock body_class %}">
   {% block header %}
-  <header class="{{ bootstrap_container_class }}">
+  <header class="page_header {{ bootstrap_container_class }}">
     {% include header_template|default:"genericsite/blocks/header_simple.html" %}
   </header>
   {% endblock header %}
@@ -47,7 +47,7 @@ video: https://ogp.me/ns/video#
   {% endblock postcontent %}
 
   {% block footer %}
-  <footer class="{{ bootstrap_container_class }}">
+  <footer class="page_footer {{ bootstrap_container_class }}">
     {% include footer_template|default:"genericsite/blocks/footer_simple.html" %}
   </footer>
   {% endblock footer %}

--- a/src/genericsite/templatetags/genericsite.py
+++ b/src/genericsite/templatetags/genericsite.py
@@ -181,4 +181,4 @@ def sitevars(context):
         This site is called {{sv.brand}}. It has a custom var: {{sv.custom}}
     """
     site = get_current_site(context["request"])
-    return SiteVar.For(site).get_value(name, default)
+    return dict(site.vars.all().values_list("name", "value"))

--- a/src/genericsite/templatetags/genericsite.py
+++ b/src/genericsite/templatetags/genericsite.py
@@ -169,3 +169,16 @@ def sitevar(context, name, default=""):
     """
     site = get_current_site(context["request"])
     return SiteVar.For(site).get_value(name, default)
+
+
+@register.simple_tag(takes_context=True)
+def sitevars(context):
+    """Retrieves a dict of all site vars for the current site, storing it in a variable.
+
+    ::
+
+        {% sitevars as sv %}
+        This site is called {{sv.brand}}. It has a custom var: {{sv.custom}}
+    """
+    site = get_current_site(context["request"])
+    return SiteVar.For(site).get_value(name, default)

--- a/src/genericsite/templatetags/genericsite.py
+++ b/src/genericsite/templatetags/genericsite.py
@@ -17,11 +17,10 @@ register = template.Library()
 def add_classes(value, arg):
     """
     Add provided classes to form field
-    :param value: form field
-    :param arg: string of classes separated by ' '
-    :return: edited field
     https://stackoverflow.com/a/60267589/15428550
     because good programmers steal.
+
+    ``{{ form.username|add_classes:"form-control" }}``
     """
     css_classes = value.field.widget.attrs.get("class", "")
     # check if class is set or empty and split its content to list (or init list)
@@ -41,11 +40,12 @@ def add_classes(value, arg):
 @register.filter
 def elided_range(value):
     """
-    Filter applied only to Page objects (from Paginator). Calls `get_elided_page_range`
+    Filter applied only to Page objects (from Paginator). Calls ``get_elided_page_range``
     on the paginator, passing the current page number as the first argument, and
     returns the result.
 
-    `{% for num in page_obj|elided_range %}{{num}} {% endfor %}`
+    ``{% for num in page_obj|elided_range %}{{num}} {% endfor %}``
+
     1 2 … 7 8 9 10 11 12 13 … 19 20
     """
     page_obj = value
@@ -87,6 +87,10 @@ def copyright_notice(context):
 
 @register.simple_tag(takes_context=True)
 def menu(context, menu_slug):
+    """Looks up a Menu object from the database by slug and stores it in the variable named after 'as'.
+
+    ``{% menu "main-nav" as menu %}``
+    """
     request = context.get("request")
     site = get_current_site(request)
     menu = None
@@ -101,6 +105,12 @@ def menu(context, menu_slug):
 
 @register.simple_tag(takes_context=True)
 def menu_active(context, menuitem: str):
+    """Returns 'active' if the current URL is "under" the given URL.
+
+    Used to style menu links to mark the current section.
+
+    ``<a href="{{ url }}" class="nav-link {% menu_active url %}" {% menu_aria_current url %}>``
+    """
     path = str(context["request"].path)
     # Special case because every url starts with /
     if menuitem == "/":
@@ -115,6 +125,12 @@ def menu_active(context, menuitem: str):
 
 @register.simple_tag(takes_context=True)
 def menu_aria_current(context, menuitem: str):
+    """Adds ``aria-current="page"`` if the current URL is "under" the given URL.
+
+    Used to style menu links to mark the current section.
+
+    ``<a href="{{ url }}" class="nav-link {% menu_active url %}" {% menu_aria_current url %}>``
+    """
     path = str(context["request"].path)
     if path == menuitem:
         return 'aria-current="page" '
@@ -125,7 +141,11 @@ def menu_aria_current(context, menuitem: str):
 
 @register.simple_tag(takes_context=True)
 def opengraph_image(context, og):
-    "For an Open Graph compatible item, return an open graph image."
+    """For an Open Graph compatible item, return an Image instance suitable to
+    represent the item in a visual context.
+
+    ``{% opengraph_image article as img %}``
+    """
     if img := getattr(og, "og_image"):
         return img
     if hasattr(og, "image_set"):
@@ -139,5 +159,13 @@ def opengraph_image(context, og):
 
 @register.simple_tag(takes_context=True)
 def sitevar(context, name, default=""):
+    """Retrieves the value of a SiteVar from the database, either printing it
+    or storing it in a variable.
+
+    ::
+
+        {% sitevar "custom" as custom %}
+        This site is called {% sitevar "brand" %}. It has a custom var: {{custom}}
+    """
     site = get_current_site(context["request"])
     return SiteVar.For(site).get_value(name, default)

--- a/src/genericsite/views.py
+++ b/src/genericsite/views.py
@@ -30,7 +30,7 @@ class OpenGraphDetailView(DetailView):
 
         # Fall back to site default if set
         var = self.object.site.vars
-        if site_default := var.get_value("default_base_template"):
+        if site_default := var.get_value("base_template"):
             names.append(site_default)
 
         # Fall back to Genericsite default
@@ -72,17 +72,17 @@ class OpenGraphListView(ListView):
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        conf = apps.get_app_config("genericsite")
         site = get_current_site(self.request)
         context = super().get_context_data(**kwargs)
         context["object"] = self.object
         context["opengraph"] = self.object.opengraph
+        context["precontent_template"] = site.vars.get_value("list_precontent_template")
         context[
             "content_template"
-        ] = self.object.content_template or site.vars.get_value(
-            "default_list_content_template", conf.default_list_content_template
+        ] = self.object.content_template or site.vars.get_value("list_content_template")
+        context["postcontent_template"] = site.vars.get_value(
+            "list_postcontent_template"
         )
-
         return context
 
     def get_context_object_name(self, object_list):
@@ -96,14 +96,14 @@ class OpenGraphListView(ListView):
         if paginate_by := super().get_paginate_by(queryset):
             return paginate_by
         # Fall back to per-site setting or None
-        return self.request.site.vars.get_value("paginate_by")
+        return self.request.site.vars.get_value("paginate_by", None, asa=int)
 
     def get_paginate_orphans(self) -> int:
         # If set explicitly on class, return it
         if orphans := super().get_paginate_orphans():
             return orphans
         # Fall back to per-site setting or 0 (Django's default)
-        return self.request.site.vars.get_value("paginate_orphans", 0)
+        return self.request.site.vars.get_value("paginate_orphans", 0, asa=int)
 
     def get_queryset(self):
         site = get_current_site(self.request)
@@ -133,7 +133,7 @@ class OpenGraphListView(ListView):
 
         # Fall back to site default if set
         var = self.object.site.vars
-        if site_default := var.get_value("default_base_template"):
+        if site_default := var.get_value("base_template"):
             names.append(site_default)
 
         # Fall back to Genericsite default

--- a/src/genericsite/views.py
+++ b/src/genericsite/views.py
@@ -14,8 +14,16 @@ class OpenGraphDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        conf = apps.get_app_config("genericsite")
+
         context["opengraph"] = self.object.opengraph
-        if custom_template := getattr(self.object, "content_template", ""):
+
+        # Allow passing kwargs in the urlconf to override the default block templates
+        for block in conf.base_blocks:
+            if tpl := self.kwargs.get(block):
+                context[block] = tpl
+
+        if custom_template := getattr(self.object, "content_template"):
             context["content_template"] = custom_template
         return context
 
@@ -73,6 +81,7 @@ class OpenGraphListView(ListView):
 
     def get_context_data(self, **kwargs):
         site = get_current_site(self.request)
+        conf = apps.get_app_config("genericsite")
         context = super().get_context_data(**kwargs)
         context["object"] = self.object
         context["opengraph"] = self.object.opengraph
@@ -83,6 +92,12 @@ class OpenGraphListView(ListView):
         context["postcontent_template"] = site.vars.get_value(
             "list_postcontent_template"
         )
+
+        # Allow passing kwargs in the urlconf to override the default block templates
+        for block in conf.base_blocks:
+            if tpl := self.kwargs.get(block):
+                context[block] = tpl
+
         return context
 
     def get_context_object_name(self, object_list):

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     "tinymce",
     # Standard Django stuff
     "django.contrib.admin",
+    "django.contrib.admindocs",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.messages",

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("accounts/profile/", generic.ProfileView.as_view(), name="account_profile"),
     path("accounts/", include("allauth.urls")),
     path("django_accounts/", include("django.contrib.auth.urls")),
+    path("admin/doc/", include("django.contrib.admindocs.urls")),
     path("admin/", admin.site.urls),
     path("tinymce/", include("tinymce.urls")),
     path(


### PR DESCRIPTION
Since get_value now falls back to appconfig, much of the code for finding defaults can be simplified. App defaults have been renamed to support this.

Resolves #16 
Resolves #1 